### PR TITLE
【fix】習慣ログのステータスとrakeタスクのスケジュールの修正

### DIFF
--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -34,7 +34,7 @@ class Habit < ApplicationRecord
   private
 
   def generate_initial_logs
-    (start_date..Date.today).each do |date|
+    (start_date.to_date..Date.today).each do |date|
       habit_logs.find_or_create_by(date: date)
     end
   end

--- a/app/models/habit_log.rb
+++ b/app/models/habit_log.rb
@@ -1,10 +1,9 @@
 class HabitLog < ApplicationRecord
   belongs_to :habit
 
-  enum status: { incomplete: 0, complete: 1 }
+  enum status: { not_completed: 0, completed: 1 }
 
   validates :date, presence: true
-  validates :status, presence: true
   validates :habit_id, uniqueness: { scope: :date, message: "has already been logged for this date" }
   validate :date_cannot_be_before_habit_start
 

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -11,10 +11,10 @@
           <th>Type</th>
           <th>Description</th>
           <th>Start Date</th>
-          <th>Actions</th>
           <th>Total Completed Days</th>
           <th>Continuous Completed Days</th>
           <th>Completion Rate</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -71,11 +71,11 @@
             <td><%= log.status %></td>
             <td>
               <% if log.status.nil? %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
                   <%= form.hidden_field :status, value: 'completed' %>
                   <%= form.submit 'Mark as Completed', class: 'btn btn-success btn-sm' %>
                 <% end %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
                   <%= form.hidden_field :status, value: 'not_completed' %>
                   <%= form.submit 'Mark as Not Completed', class: 'btn btn-danger btn-sm' %>
                 <% end %>

--- a/compose.yml
+++ b/compose.yml
@@ -26,6 +26,10 @@ services:
       - bundle_data:/usr/local/bundle:cached
       - node_modules:/app/node_modules
     environment:
+      DATABASE_USERNAME: root
+      DATABASE_PASSWORD: password
+      DATABASE_HOST: db
+      RAILS_ENV: development
       TZ: Asia/Tokyo
     ports:
       - "3000:3000"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'habits#index'
 
   resources :habits do
-    resources :habit_logs, only: [:new, :create, :index]
+    resources :habit_logs, only: [:new, :create, :index, :update]
   end
   resources :users
 

--- a/db/migrate/20240603153012_remove_default_status_and_not_null_from_habit_logs.rb
+++ b/db/migrate/20240603153012_remove_default_status_and_not_null_from_habit_logs.rb
@@ -1,0 +1,7 @@
+class RemoveDefaultStatusAndNotNullFromHabitLogs < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :habit_logs, :status, nil
+    change_column_null :habit_logs, :status, true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_29_153540) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_03_153012) do
   create_table "habit_logs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "habit_id", null: false
     t.date "date", null: false
-    t.integer "status", default: 0, null: false
+    t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["habit_id", "date"], name: "index_habit_logs_on_habit_id_and_date", unique: true

--- a/lib/tasks/daily_tasks.rake
+++ b/lib/tasks/daily_tasks.rake
@@ -3,7 +3,7 @@ namespace :daily_tasks do
   task create_habit_logs: :environment do
     Habit.where('start_date <= ?', Date.today).find_each do |habit|
       unless habit.habit_logs.exists?(date: Date.today)
-        habit.habit_logs.create(date: Date.today, status: 'incomplete')
+        habit.habit_logs.create(date: Date.today)
       end
     end
   end

--- a/lib/tasks/habit_logs.rake
+++ b/lib/tasks/habit_logs.rake
@@ -4,9 +4,7 @@ namespace :habit_logs do
     Habit.find_each do |habit|
       start_date = habit.start_date.to_date
       (start_date..Date.today).each do |date|
-        HabitLog.find_or_create_by(habit: habit, date: date) do |log|
-          log.status = 'incomplete' # 適切なデフォルト値を設定
-        end
+        HabitLog.find_or_create_by(habit: habit, date: date)
       end
     end
   end


### PR DESCRIPTION
### 変更内容

- `habit_log` モデルの `status` カラムのデフォルト値と `null` 設定を修正しました。
  - `status` カラムのデフォルト値を削除し、`null` 設定を許可しました。
- `habit_log` のステータスを `not_completed` と `completed` に修正しました。
- `habit_log` を生成する `rake` タスクのステータス設定を修正しました。
- 習慣ログのフォームが正しく表示されるようにビューを修正しました。
- cronジョブが正しく設定されるように `whenever` の設定を修正しました。
- `compose.yml` における環境変数の設定を修正しました。
- `config/routes.rb` を更新し、適切なルーティングを追加しました。