### PR TITLE
【feature】習慣記録リマインダー通知機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,19 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
   add_flash_types :info, :success, :warning, :error
+  before_action :set_unlogged_habit_logs
 
   private
 
   def not_authenticated
     redirect_to login_path, alert: "Please login first"
+  end
+
+  def set_unlogged_habit_logs
+    if current_user
+      @unlogged_habit_logs = current_user.habits
+                                         .joins(:habit_logs)
+                                         .where(habit_logs: { date: Date.today, status: nil })
+    end
   end
 end

--- a/app/controllers/unlogged_habit_logs_controller.rb
+++ b/app/controllers/unlogged_habit_logs_controller.rb
@@ -1,0 +1,6 @@
+class UnloggedHabitLogsController < ApplicationController
+  def index
+    @unlogged_habit_logs = HabitLog.joins(:habit)
+                                   .where(habits: { user_id: current_user.id }, date: Date.today, status: nil)
+  end
+end

--- a/app/helpers/unlogged_habit_logs_helper.rb
+++ b/app/helpers/unlogged_habit_logs_helper.rb
@@ -1,0 +1,2 @@
+module UnloggedHabitLogsHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,8 @@
 
     <%= render 'shared/flash_message' %>
 
+    <%= render 'shared/unlogged_habit_logs_alert' %>
+
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_unlogged_habit_logs_alert.html.erb
+++ b/app/views/shared/_unlogged_habit_logs_alert.html.erb
@@ -1,0 +1,6 @@
+<% if @unlogged_habit_logs.present? %>
+  <div class="alert alert-warning">
+    <p>達成状況が未記録の習慣ログがあります！</p>
+    <%= link_to '未記録の習慣ログ一覧を見る', unlogged_habit_logs_path, class: 'alert-link' %>
+  </div>
+<% end %>

--- a/app/views/unlogged_habit_logs/index.html.erb
+++ b/app/views/unlogged_habit_logs/index.html.erb
@@ -1,0 +1,31 @@
+<div class="container mx-auto w-full max-w-2xl">
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">未記録の習慣ログ一覧</h2>
+
+  <table class="table">
+    <thead>
+      <tr>
+        <th>習慣名</th>
+        <th>日付</th>
+        <th>アクション</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @unlogged_habit_logs.each do |log| %>
+        <tr>
+          <td><%= log.habit.name %></td>
+          <td><%= log.date %></td>
+          <td>
+            <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
+              <%= form.hidden_field :status, value: 'completed' %>
+              <%= form.submit '完了にする', class: 'btn btn-success btn-sm' %>
+            <% end %>
+            <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
+              <%= form.hidden_field :status, value: 'not_completed' %>
+              <%= form.submit '未完了にする', class: 'btn btn-danger btn-sm' %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,12 @@ Rails.application.routes.draw do
   resources :habits do
     resources :habit_logs, only: [:new, :create, :index, :update]
   end
+
   resources :users
 
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"
   delete 'logout' => 'user_sessions#destroy', :as => :logout
+
+  get 'unlogged_habit_logs', to: 'unlogged_habit_logs#index', as: 'unlogged_habit_logs'
 end

--- a/test/controllers/unlogged_habit_logs_controller_test.rb
+++ b/test/controllers/unlogged_habit_logs_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UnloggedHabitLogsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get unlogged_habit_logs_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要

このプルリクエストは、ユーザーに習慣の達成状況を記録するようリマインドする機能を実装します。
未記録の習慣ログが存在する場合、ユーザーに通知を表示します。

## 変更内容

1. **未記録の習慣ログ一覧を表示するためのロジックの実装**
    - `UnloggedHabitLogsController` の作成。
    - `index` アクションで未記録の習慣ログを取得。

2. **ルーティングの追加**
    - 未記録の習慣ログ一覧ページのルートを追加。

3. **アラートメッセージの表示**
    - `app/views/shared/_unlogged_habit_logs_alert.html.erb` を作成し、未記録の習慣ログが存在する場合にアラートを表示。
    - `ApplicationController` に `set_unlogged_habits` メソッドを追加し、未記録の習慣ログを設定。

4. **未記録の習慣ログ一覧ページの作成**
    - `app/views/unlogged_habit_logs/index.html.erb` に未記録の習慣ログ一覧を表示するテーブルを作成。
