### PR TITLE
【refactor】ビューの調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'whenever', require: false
 
 gem 'kaminari'
 
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -309,6 +312,7 @@ DEPENDENCIES
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/controllers/habit_logs_controller.rb
+++ b/app/controllers/habit_logs_controller.rb
@@ -3,7 +3,7 @@ class HabitLogsController < ApplicationController
   before_action :set_habit_log, only: [:update]
 
   def index
-    @habit_logs = @habit.habit_logs.order(:date)
+    @habit_logs = @habit.habit_logs.order(date: :desc)
     if params[:filter] == 'incomplete'
       @habit_logs = @habit_logs.where(status: nil)
     end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to(:users, success: 'Login successful')
+      redirect_back_or_to(root_path, success: 'Login successful')
     else
       flash.now[:danger] = 'Login failed'
       render :new

--- a/app/views/habit_logs/index.html.erb
+++ b/app/views/habit_logs/index.html.erb
@@ -1,13 +1,6 @@
 <div class="mx-auto w-full max-w-2xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Habit Logs for <%= @habit.name %></h2>
 
-  <div class="form-control max-w-64 float-right">
-    <label class="label cursor-pointer">
-      <span class="label-text mx-2">Incomplete Logs</span>
-      <%= check_box_tag 'filter', 'incomplete', params[:filter] == 'incomplete', class: 'toggle toggle-primary mx-2', data: { toggle_url: habit_habit_logs_path(@habit, filter: 'incomplete'), toggle_all_url: habit_habit_logs_path(@habit) } %>
-    </label>
-  </div>
-
   <table class="table">
     <thead>
       <tr>
@@ -23,16 +16,18 @@
             <td><%= log.date %></td>
             <td><%= log.status %></td>
             <td>
-              <% if log.status.nil? %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
-                  <%= form.hidden_field :status, value: 'completed' %>
-                  <%= form.submit 'Mark as Completed', class: 'btn btn-success btn-sm' %>
+              <div class="flex">
+                <% if log.status.nil? %>
+                  <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                    <%= form.hidden_field :status, value: 'completed' %>
+                    <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
+                  <% end %>
+                  <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                    <%= form.hidden_field :status, value: 'not_completed' %>
+                    <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
+                  <% end %>
                 <% end %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
-                  <%= form.hidden_field :status, value: 'not_completed' %>
-                  <%= form.submit 'Mark as Not Completed', class: 'btn btn-danger btn-sm' %>
-                <% end %>
-              <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -1,44 +1,48 @@
 <div class="mx-auto w-full max-w-5xl">
-  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Habits</h2>
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Your Habits</h2>
 
   <div class="container">
     <%= link_to 'New Habit', new_habit_path, class: 'my-3 btn btn-primary' %>
 
-    <table class="my-3 table">
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Description</th>
-          <th>Start Date</th>
-          <th>Total Completed Days</th>
-          <th>Continuous Completed Days</th>
-          <th>Completion Rate</th>
-          <th>Public</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @habits.each do |habit| %>
-          <tr class="hover">
-            <td><%= habit.name %></td>
-            <td><%= habit.habit_type %></td>
-            <td><%= habit.description %></td>
-            <td><%= habit.start_date.strftime("%Y-%m-%d") %></td>
-            <td><%= habit.total_completed_days %></td>
-            <td><%= habit.continuous_completed_days %></td>
-            <td><%= habit.completion_rate %></td>
-            <td><%= habit.public ? 'Yes' : 'No' %></td>
-            <td>
-              <%= link_to 'Show', habit, class: 'btn btn-secondary btn-outline btn-xs' %>
-              <% if current_user.own?(habit) %>
-                <%= link_to 'Edit', edit_habit_path(habit), id: "button-edit-#{habit.id}", class: 'btn btn-secondary btn-xs' %>
-                <%= link_to 'Delete', habit_path(habit), id: "button-delete-#{habit.id}", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' %>
-              <% end %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <div class="list">
+      <% @habits.each do |habit| %>
+        <div class="card bg-base-100 shadow-xl my-3">
+          <div class="card-body">
+            <div class="flex">
+              <h2 class="flex-1 card-title"><%= habit.name %></h2>
+              <div class="flex-none mx-5 font-bold text-info">
+                <%= habit.public ? 'Public' : 'Private' %>
+              </div>
+              <div class="flex-none">
+                <%= link_to 'Show', habit, class: 'btn btn-info btn-outline btn-xs' %>
+                <% if current_user.own?(habit) %>
+                  <%= link_to 'Edit', edit_habit_path(habit), id: "button-edit-#{habit.id}", class: 'btn btn-secondary btn-xs' %>
+                  <%= link_to 'Delete', habit_path(habit), id: "button-delete-#{habit.id}", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' %>
+                <% end %>
+              </div>
+            </div>
+            <p>Type: <%= habit.habit_type %></p>
+            <p><%= habit.description %></p>
+            <p>Start Date: <%= habit.start_date.strftime("%Y-%m-%d") %></p>
+
+            <div class="stats shadow">
+              <div class="stat">
+                <div class="stat-title">Total Completed Days:</div>
+                <div class="stat-value text-primary"><%= habit.total_completed_days %></div>
+              </div>
+              <div class="stat">
+                <div class="stat-title">Continuous Completed Days:</div>
+                <div class="stat-value text-primary"><%= habit.continuous_completed_days %></div>
+              </div>
+              <div class="stat">
+                <div class="stat-title">Completion Rate:</div>
+                <div class="stat-value text-primary"><%= habit.completion_rate %></div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -77,16 +77,18 @@
             <td><%= log.date %></td>
             <td><%= log.status %></td>
             <td>
-              <% if log.status.nil? %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
-                  <%= form.hidden_field :status, value: 'completed' %>
-                  <%= form.submit 'Mark as Completed', class: 'btn btn-success btn-sm' %>
+              <div class="flex">
+                <% if log.status.nil? %>
+                  <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
+                    <%= form.hidden_field :status, value: 'completed' %>
+                    <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
+                  <% end %>
+                  <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
+                    <%= form.hidden_field :status, value: 'not_completed' %>
+                    <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
+                  <% end %>
                 <% end %>
-                <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
-                  <%= form.hidden_field :status, value: 'not_completed' %>
-                  <%= form.submit 'Mark as Not Completed', class: 'btn btn-danger btn-sm' %>
-                <% end %>
-              <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/public_habits/index.html.erb
+++ b/app/views/public_habits/index.html.erb
@@ -1,24 +1,59 @@
 <div class="mx-auto w-full max-w-5xl">
-  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Public Habits</h2>
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Everyone's Habits</h2>
 
-  <%= form_with url: public_habits_path, method: :get, local: true do |form| %>
-    <div>
-      <%= form.label :sort, "Sort by" %>
-      <%= form.select :sort, options_for_select([['Newest', 'newest'], ['Oldest', 'oldest']], params[:sort]) %>
-    </div>
-    <div>
-      <%= form.label :habit_type, "Habit Type" %>
-      <%= form.select :habit_type, options_for_select(Habit.habit_types.keys.map { |k| [k.humanize, k] }, params[:habit_type]) %>
-    </div>
-    <div>
-      <%= form.submit "Filter" %>
-    </div>
-  <% end %>
-  <div class="habits-list">
+  <div class="mb-4 flex items-center">
+    <%= form_with(url: public_habits_path, method: :get, local: true, class: "flex items-center space-x-2") do |form| %>
+      <div>
+        <%= form.label :sort, "Sort by", class: "mr-2" %>
+        <%= form.select :sort, options_for_select([['Newest', 'newest'], ['Oldest', 'oldest']], params[:sort]), {}, { class: "select select-bordered" } %>
+      </div>
+      <div>
+        <%= form.label :habit_type, "Habit Type", class: "mr-2 ml-4" %>
+        <%= form.select :habit_type, options_for_select(Habit.habit_types.keys.map { |k| [k.humanize, k] }, params[:habit_type]), {}, { class: "select select-bordered" } %>
+      </div>
+      <div>
+        <%= form.submit "Filter", class: "btn btn-primary ml-4" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="list">
     <% @habits.each do |habit| %>
-      <div class="card">
-        <h2><%= link_to habit.name, habit_path(habit) %></h2>
-        <p><%= habit.description %></p>
+      <div class="card bg-base-100 shadow-xl my-3">
+        <div class="card-body">
+          <div class="flex">
+            <h2 class="flex-1 card-title"><%= habit.name %></h2>
+            <div class="flex-none mx-5 font-bold text-info">
+              <%= habit.public ? 'Public' : 'Private' %>
+            </div>
+            <div class="flex-none">
+              <%= link_to 'Show', habit, class: 'btn btn-info btn-outline btn-xs' %>
+              <% if current_user.own?(habit) %>
+                <%= link_to 'Edit', edit_habit_path(habit), id: "button-edit-#{habit.id}", class: 'btn btn-secondary btn-xs' %>
+                <%= link_to 'Delete', habit_path(habit), id: "button-delete-#{habit.id}", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' %>
+              <% end %>
+            </div>
+          </div>
+          <p>Type: <%= habit.habit_type %></p>
+          <p><%= habit.description %></p>
+          <p>Start Date: <%= habit.start_date.strftime("%Y-%m-%d") %></p>
+
+          <div class="stats shadow">
+            <div class="stat">
+              <div class="stat-title">Total Completed Days:</div>
+              <div class="stat-value text-primary"><%= habit.total_completed_days %></div>
+            </div>
+            <div class="stat">
+              <div class="stat-title">Continuous Completed Days:</div>
+              <div class="stat-value text-primary"><%= habit.continuous_completed_days %></div>
+            </div>
+            <div class="stat">
+              <div class="stat-title">Completion Rate:</div>
+              <div class="stat-value text-primary"><%= habit.completion_rate %></div>
+            </div>
+          </div>
+
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/rewards/index.html.erb
+++ b/app/views/rewards/index.html.erb
@@ -1,11 +1,33 @@
 <div class="mx-auto w-full max-w-5xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">All Rewards</h2>
 
-  <ul>
-    <% @rewards.each do |reward| %>
-      <li>
-        <%= link_to reward.name, reward_path(reward) %>
-      </li>
-    <% end %>
-  </ul>
+  <div class="container">
+    <div class="list">
+      <% @rewards.each do |reward| %>
+        <div class="card bg-base-100 shadow-xl my-3">
+          <div class="card-body">
+            <div class="flex">
+              <h2 class="flex-1 card-title"><%= reward.name %></h2>
+              <div class="flex-none mx-5 font-bold text-info">
+
+              </div>
+              <div class="flex-none">
+                <%= link_to 'Show', reward_path(reward), class: 'btn btn-info btn-outline btn-xs' %>
+              </div>
+            </div>
+            <p><%= reward.description %></p>
+            <p>
+              <%= if reward.condition_type == 'continuous_days'
+                    "連続で#{reward.threshold}日達成"
+                  elsif reward.condition_type == 'total_days'
+                    "合計で#{reward.threshold}日達成"
+                  else
+                    reward.condition_type
+                  end %>
+            </p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -16,9 +16,9 @@
   <p>
     <strong class="my-2 w-full block leading-6 text-gray-900">Condition:</strong>
     <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @reward.condition %>
+      <%= @reward.condition_type %>
     </div>
   </p>
 
-  <%= link_to 'Back to Rewards', rewards_path %>
+  <%= link_to 'Back to Rewards', rewards_path, class: 'btn btn-primary btn-outline flex-auto w-full ml-2' %>
 </div>

--- a/app/views/rewards/user_rewards.html.erb
+++ b/app/views/rewards/user_rewards.html.erb
@@ -1,6 +1,11 @@
 <div class="mx-auto w-full max-w-5xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Your Rewards</h2>
 
+  <div class="flex justify-between items-center my-5">
+    <h3 class="text-xl font-bold leading-9 tracking-tight text-gray-900"></h3>
+    <%= link_to 'All Rewards >', rewards_path, class: 'link link-primary link-hover' %>
+  </div>
+
   <ul>
     <% @user_rewards.each do |reward| %>
       <li>
@@ -8,6 +13,4 @@
       </li>
     <% end %>
   </ul>
-
-  <%= link_to 'Back to All Rewards', rewards_path %>
 </div>

--- a/app/views/shared/_admin_header.html.erb
+++ b/app/views/shared/_admin_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <div class="navbar bg-base-100">
     <div class="flex-1">
-      <a class="btn btn-ghost text-xl text-rose-700">Lockaway</a>
+      <%= link_to "LockAway", root_path, class: "btn btn-ghost text-xl text-rose-700" %>
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,10 +1,16 @@
 <header>
   <div class="navbar bg-base-100">
     <div class="flex-1">
-      <%= link_to "Lockaway", root_path, class: "btn btn-ghost text-xl" %>
+      <a class="btn btn-ghost text-xl">LockAway</a>
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
+        <li>
+          <%= link_to "Everyone's Habits", public_habits_path %>
+        </li>
+        <li>
+          <%= link_to "Everyone's Rewards", public_rewards_path %>
+        </li>
         <li>
           <%= link_to "Sign up", new_user_path %>
         </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,15 +1,15 @@
 <header>
   <div class="navbar bg-base-100">
     <div class="flex-1">
-      <a class="btn btn-ghost text-xl">Lockaway</a>
+      <%= link_to "LockAway", root_path, class: "btn btn-ghost text-xl" %>
     </div>
     <div class="flex-none">
       <ul class="menu menu-horizontal px-1">
         <li>
-          <%= link_to "Home", "#" %>
+          <%= link_to "Everyone's Habits", public_habits_path %>
         </li>
         <li>
-          <%= link_to "User List", users_path %>
+          <%= link_to "Everyone's Rewards", public_rewards_path %>
         </li>
         <li>
           <details>
@@ -18,7 +18,10 @@
             </summary>
             <ul class="p-2 bg-base-100 rounded-t-none">
               <li>
-                <%= link_to "Profile", "#" %>
+                <%= link_to "Your Habits", habits_path %>
+              </li>
+              <li>
+                <%= link_to "Your Rewards", user_rewards_rewards_path %>
               </li>
               <li>
                 <%= link_to "Logout", logout_path, data: {turbo_method: :delete} %>

--- a/app/views/unlogged_habit_logs/index.html.erb
+++ b/app/views/unlogged_habit_logs/index.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto w-full max-w-2xl">
-  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">未記録の習慣ログ一覧</h2>
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Unlogged HabitLogs</h2>
 
   <table class="table">
     <thead>
       <tr>
-        <th>習慣名</th>
-        <th>日付</th>
-        <th>アクション</th>
+        <th>Name</th>
+        <th>Start Date</th>
+        <th>Action</th>
       </tr>
     </thead>
     <tbody>
@@ -15,14 +15,18 @@
           <td><%= log.habit.name %></td>
           <td><%= log.date %></td>
           <td>
-            <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
-              <%= form.hidden_field :status, value: 'completed' %>
-              <%= form.submit '完了にする', class: 'btn btn-success btn-sm' %>
-            <% end %>
-            <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
-              <%= form.hidden_field :status, value: 'not_completed' %>
-              <%= form.submit '未完了にする', class: 'btn btn-danger btn-sm' %>
-            <% end %>
+            <div class="flex">
+              <% if log.status.nil? %>
+                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                  <%= form.hidden_field :status, value: 'completed' %>
+                  <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
+                <% end %>
+                <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
+                  <%= form.hidden_field :status, value: 'not_completed' %>
+                  <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
+                <% end %>
+              <% end %>
+            </div>
           </td>
         </tr>
       <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+      habit: "習慣"
+      reward: "報酬"
+    attributes:
+      user:
+        username: "ユーザー名"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+      habit:
+        name: "名前"
+        habit_type: "種類"
+        description: "説明"
+        start_date: "開始日"
+      reward:
+        name: "名前"
+        description: "説明"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,27 @@
+ja:
+  hello: "こんにちは"
+  login: "ログイン"
+  logout: "ログアウト"
+  admin:
+    dashboard: "管理者ダッシュボード"
+  users:
+    index:
+      title: "ユーザー一覧"
+    new:
+      title: "新しいユーザー"
+    edit:
+      title: "ユーザー編集"
+  habits:
+    index:
+      title: "習慣一覧"
+    new:
+      title: "新しい習慣"
+    edit:
+      title: "習慣編集"
+  rewards:
+    index:
+      title: "報酬一覧"
+  buttons:
+    create: "作成"
+    update: "更新"
+    delete: "削除"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root 'habits#index'
+  root 'public_habits#index'
 
   get 'login', to: 'user_sessions#new', as: :login
   post 'login', to: 'user_sessions#create'


### PR DESCRIPTION
### 概要

このプルリクエストでは、以下の変更を行いました。
1. 日本語の翻訳ファイルの作成と `rails-i18n` gem のインストール
2. ログイン後の遷移先およびヘッダーの修正
3. 習慣および報酬の一覧表示ビューの調整
4. 習慣ログの記録ボタンの修正

### 詳細

1. 日本語の翻訳ファイルの作成と `rails-i18n` gem のインストール
  - Gemfileに`rails-i18n` gemを追加し、`bundle install`を実行しました。
  - config/locales/ja.ymlとconfig/locales/views/ja.ymlを作成し、日本語の翻訳ファイルを用意しました。

2. ログイン後の遷移先およびヘッダーの修正
  - ユーザーおよび管理者のログイン後の遷移先を適切に変更しました。
  - current_adminメソッドを削除し、ユーザーの役割に基づいてヘッダーを表示するように変更しました。

3. 習慣および報酬の一覧表示ビューの調整
  - 習慣一覧表示をカード形式で表示するように変更しました。
  - 報酬一覧表示を習慣一覧と同様のカード形式で表示するように変更しました。

4. 習慣ログの記録ボタンの修正
  - 習慣ログを最新順に表示するように変更しました。
  - 記録ボタンのスタイルと機能を改善しました。

### その他

- 実際に国際化するのは別のIssueとします。
