### PR TITLE
【feature】`public_habits#show`の追加

### DIFF
--- a/app/controllers/public_habits_controller.rb
+++ b/app/controllers/public_habits_controller.rb
@@ -1,5 +1,5 @@
 class PublicHabitsController < ApplicationController
-  skip_before_action :require_login, only: [:index]
+  skip_before_action :require_login, only: [:index, :show]
 
   def index
     @habits = Habit.public_habits
@@ -7,5 +7,9 @@ class PublicHabitsController < ApplicationController
     @habits = @habits.order(created_at: :asc) if params[:sort] == 'oldest'
     @habits = @habits.where(habit_type: params[:habit_type]) if params[:habit_type].present?
     @habits = @habits.page(params[:page])
+  end
+
+  def show
+    @habit = Habit.public_habits.find(params[:id])
   end
 end

--- a/app/views/public_habits/index.html.erb
+++ b/app/views/public_habits/index.html.erb
@@ -27,7 +27,7 @@
               <%= habit.public ? 'Public' : 'Private' %>
             </div>
             <div class="flex-none">
-              <%= link_to 'Show', habit, class: 'btn btn-info btn-outline btn-xs' %>
+              <%= link_to 'Show', public_habit_path(habit), class: 'btn btn-info btn-outline btn-xs' %>
               <% if logged_in? && current_user.own?(habit) %>
                 <%= link_to 'Edit', edit_habit_path(habit), id: "button-edit-#{habit.id}", class: 'btn btn-secondary btn-xs' %>
                 <%= link_to 'Delete', habit_path(habit), id: "button-delete-#{habit.id}", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, class: 'btn btn-danger btn-xs' %>

--- a/app/views/public_habits/show.html.erb
+++ b/app/views/public_habits/show.html.erb
@@ -1,0 +1,63 @@
+<div class="container mx-auto w-full max-w-2xl">
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Habit Details</h2>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Name:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.name %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Type:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.habit_type.humanize %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Description:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.description %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Start Date:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.start_date.strftime("%Y-%m-%d") %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Total Completed Days:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.total_completed_days %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Continuous Completed Days:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.continuous_completed_days %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Completion Rate:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.completion_rate %>
+    </div>
+  </p>
+
+  <p>
+    <strong class="my-2 w-full block leading-6 text-gray-900">Public:</strong>
+    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
+      <%= @habit.public ? 'Yes' : 'No' %>
+    </div>
+  </p>
+
+  <div class="flex mt-5 mb-10">
+    <%= link_to 'Back', public_habits_path, class: 'btn btn-primary btn-outline flex-auto w-full ml-2' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :habit_logs, only: [:new, :create, :index, :update]
   end
 
-  resources :public_habits, only: [:index]
+  resources :public_habits, only: [:index, :show]
 
   resources :public_rewards, only: [:index]
 


### PR DESCRIPTION
### 概要

PublicHabitsControllerに`show`アクションを追加し、他のユーザーの公開された習慣の詳細を表示できるようにしました。

### 変更内容

- `PublicHabitsController`に`show`アクションを追加
- `public_habits/show.html.erb`を新規作成
- ルーティングに`public_habits#show`を追加

### 動作確認

1. 公開された習慣の一覧ページ（`public_habits#index`）にアクセス。
2. 任意の習慣の「Show」ボタンをクリック。
3. 習慣の詳細ページに遷移し、詳細情報が表示されることを確認。
