### PR TITLE
【fix】習慣ログ達成時のリダイレクト先とTurboフレーム対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,9 +11,8 @@ class ApplicationController < ActionController::Base
 
   def set_unlogged_habit_logs
     if current_user
-      @unlogged_habit_logs = current_user.habits
-                                         .joins(:habit_logs)
-                                         .where(habit_logs: { date: Date.today, status: nil })
+      @unlogged_habit_logs = HabitLog.joins(:habit)
+                                     .where(habits: { user_id: current_user.id }, status: nil)
     end
   end
 

--- a/app/views/habit_logs/index.html.erb
+++ b/app/views/habit_logs/index.html.erb
@@ -12,24 +12,7 @@
     <tbody>
       <% if @habit_logs.present? %>
         <% @habit_logs.each do |log| %>
-          <tr>
-            <td><%= log.date %></td>
-            <td><%= log.status %></td>
-            <td>
-              <div class="flex">
-                <% if log.status.nil? %>
-                  <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
-                    <%= form.hidden_field :status, value: 'completed' %>
-                    <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
-                  <% end %>
-                  <%= form_with(model: [@habit, log], local: true, method: :patch) do |form| %>
-                    <%= form.hidden_field :status, value: 'not_completed' %>
-                    <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
-                  <% end %>
-                <% end %>
-              </div>
-            </td>
-          </tr>
+          <%= render partial: 'shared/habit_log', locals: { habit_log: log } %>
         <% end %>
       <% else %>
         <tr>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -73,24 +73,7 @@
       </thead>
       <tbody>
         <% @habit.habit_logs.order(date: :desc).limit(5).each do |log| %>
-          <tr>
-            <td><%= log.date %></td>
-            <td><%= log.status %></td>
-            <td>
-              <div class="flex">
-                <% if log.status.nil? %>
-                  <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
-                    <%= form.hidden_field :status, value: 'completed' %>
-                    <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
-                  <% end %>
-                  <%= form_with(model: [@habit, log], local: true, method: :patch, url: habit_habit_log_path(@habit, log)) do |form| %>
-                    <%= form.hidden_field :status, value: 'not_completed' %>
-                    <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
-                  <% end %>
-                <% end %>
-              </div>
-            </td>
-          </tr>
+          <%= render partial: 'shared/habit_log', locals: { habit_log: log } %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Lockaway</title>
+    <title>LockAway</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -19,9 +19,13 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
 
-    <%= render 'shared/flash_message' %>
+    <turbo-frame id="flash">
+      <%= render 'shared/flash_message' %>
+    </turbo-frame>
 
-    <%= render 'shared/unlogged_habit_logs_alert' %>
+    <turbo-frame id="unlogged_habit_logs_alert">
+      <%= render 'shared/unlogged_habit_logs_alert' %>
+    </turbo-frame>
 
     <%= yield %>
   </body>

--- a/app/views/shared/_habit_log.html.erb
+++ b/app/views/shared/_habit_log.html.erb
@@ -1,0 +1,18 @@
+<tr id="habit_log_<%= habit_log.id %>">
+  <td><%= habit_log.date %></td>
+  <td><%= habit_log.status %></td>
+  <td>
+    <div class="flex">
+      <% if habit_log.status.nil? %>
+        <%= form_with(model: [habit_log.habit, habit_log], local: true, method: :patch) do |form| %>
+          <%= form.hidden_field :status, value: 'completed' %>
+          <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
+        <% end %>
+        <%= form_with(model: [habit_log.habit, habit_log], local: true, method: :patch) do |form| %>
+          <%= form.hidden_field :status, value: 'not_completed' %>
+          <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
+        <% end %>
+      <% end %>
+    </div>
+  </td>
+</tr>

--- a/app/views/shared/_unlogged_habit_log.html.erb
+++ b/app/views/shared/_unlogged_habit_log.html.erb
@@ -1,0 +1,20 @@
+<tr id="unlogged_habit_log_<%= log.id %>">
+  <td><%= log.habit.name %></td>
+  <td><%= log.date %></td>
+  <td>
+    <div class="flex">
+      <% if log.status.nil? %>
+        <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
+          <%= form.hidden_field :status, value: 'completed' %>
+          <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
+        <% end %>
+        <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
+          <%= form.hidden_field :status, value: 'not_completed' %>
+          <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
+        <% end %>
+      <% else %>
+        <span><%= log.status %></span>
+      <% end %>
+    </div>
+  </td>
+</tr>

--- a/app/views/shared/_unlogged_habit_logs_alert.html.erb
+++ b/app/views/shared/_unlogged_habit_logs_alert.html.erb
@@ -1,6 +1,6 @@
 <% if @unlogged_habit_logs.present? %>
   <div class="alert alert-warning">
     <p>達成状況が未記録の習慣ログがあります！</p>
-    <%= link_to '未記録の習慣ログ一覧を見る', unlogged_habit_logs_path, class: 'alert-link' %>
+    <%= link_to '未記録の習慣ログ一覧を見る', unlogged_habit_logs_path, class: 'alert-link', data: { turbo_frame: '_top' } %>
   </div>
 <% end %>

--- a/app/views/unlogged_habit_logs/index.html.erb
+++ b/app/views/unlogged_habit_logs/index.html.erb
@@ -11,24 +11,7 @@
     </thead>
     <tbody>
       <% @unlogged_habit_logs.each do |log| %>
-        <tr>
-          <td><%= log.habit.name %></td>
-          <td><%= log.date %></td>
-          <td>
-            <div class="flex">
-              <% if log.status.nil? %>
-                <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
-                  <%= form.hidden_field :status, value: 'completed' %>
-                  <%= form.submit 'Completed', class: 'btn btn-success btn-xs flex mx-1' %>
-                <% end %>
-                <%= form_with(model: [log.habit, log], local: true, method: :patch) do |form| %>
-                  <%= form.hidden_field :status, value: 'not_completed' %>
-                  <%= form.submit 'Not Completed', class: 'btn btn-error btn-xs flex mx-1' %>
-                <% end %>
-              <% end %>
-            </div>
-          </td>
-        </tr>
+        <%= render partial: 'shared/unlogged_habit_log', locals: { log: log } %>
       <% end %>
     </tbody>
   </table>


### PR DESCRIPTION
### 概要

このプルリクエストでは、習慣ログの達成時に正しいページへリダイレクトするように修正し、Turboフレームを用いて更新後の要素が即座にレンダリングされるようにしました。

### 変更内容

1. **習慣ログ達成時のリダイレクト修正:**
   - 習慣詳細ページ（`habit_logs#index`）からの習慣ログ達成時、習慣詳細ページ（`habit_logs#index`）にリダイレクトされるよう修正。
   - 習慣ログ一覧ページ（`habit_logs#index`）からの習慣ログ達成時、習慣ログ一覧ページ（`habit_logs#index`）にリダイレクトされるよう修正。
   -  未記録の習慣ログ一覧ページ（`unlogged_habit_logs#index`）からの習慣ログ達成時、未記録の習慣ログ一覧ページ（`unlogged_habit_logs#index`）にリダイレクトされるよう修正。

2. **Turboフレームの追加:**
   - Turboフレームを `layouts/application.html.erb` に追加し、特定の要素（フラッシュメッセージや未記録の習慣ログアラート）が即座に更新されるように変更。

3. **パーシャルの利用:**
   - 習慣ログの表示部分をパーシャル化（`app/views/shared/_habit_log.html.erb`）。
   - `app/views/shared/_habit_log.html.erb` パーシャルを`habit_logs#index`と`habits#show`で利用。
   - 未習慣一覧の習慣ログの表示部分をパーシャル化（`app/views/shared/_unlogged_habit_log.html.erb`）。
   - `app/views/shared/_unlogged_habit_log.html.erb` パーシャルを`unlogged_habit_logs#index`で利用。

4. **コントローラーの修正:**
   - `habit_logs_controller.rb` の `update` アクションを更新し、Turboストリームを使用して特定の要素を更新。

###  関連するIssue

- Issue #82 
