### PR TITLE
【feature】獲得報酬一覧へのソート機能・検索機能の追加

### DIFF
--- a/app/controllers/user_rewards_controller.rb
+++ b/app/controllers/user_rewards_controller.rb
@@ -1,7 +1,8 @@
 class UserRewardsController < ApplicationController
   def index
-    @user_rewards = HabitReward.includes(:habit, :reward)
-                               .where(habits: { user_id: current_user.id })
-                               .page(params[:page])
+    @q = HabitReward.includes(:habit, :reward)
+                    .where(habits: { user_id: current_user.id })
+                    .ransack(params[:q])
+    @user_rewards = @q.result.order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -67,6 +67,10 @@ class Habit < ApplicationRecord
     %w[completion_rate continuous_completed_days created_at description habit_type highest_continuous_days id name public start_date total_completed_days updated_at user_id]
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    %w[habit_logs habit_rewards rewards user]
+  end
+
   ransacker :habit_type, formatter: proc { |v| habit_types[v] } do |parent|
     parent.table[:habit_type]
   end

--- a/app/models/habit_reward.rb
+++ b/app/models/habit_reward.rb
@@ -4,4 +4,12 @@ class HabitReward < ApplicationRecord
 
   validates :habit_id, presence: true
   validates :reward_id, presence: true
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[created_at habit_id id reward_id updated_at]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[habit reward]
+  end
 end

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -9,4 +9,8 @@ class Reward < ApplicationRecord
   validates :condition_type, presence: { message: :blank }
   validates :threshold, presence: { message: :blank }, numericality: { only_integer: true, message: :not_a_number }
   validates :habit_type, presence: { message: :blank }
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[id name description condition_type habit_type threshold created_at updated_at]
+  end
 end

--- a/app/views/user_rewards/index.html.erb
+++ b/app/views/user_rewards/index.html.erb
@@ -1,9 +1,19 @@
 <div class="mx-auto w-full max-w-5xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.heading') %></h2>
 
-  <div class="flex justify-between items-center my-5">
-    <h3 class="text-xl font-bold leading-9 tracking-tight text-gray-900"></h3>
-    <%= link_to t('.all_rewards'), rewards_path, class: 'link link-primary link-hover' %>
+  <div class="mb-4 flex items-center">
+    <%= search_form_for @q, url: user_rewards_path, method: :get, local: true, class: "flex items-center space-x-2" do |form| %>
+      <%= form.label :s, t('.sort_by'), class: "mr-2 ml-4" %>
+      <%= form.select :s, options_for_select([[t('.newest'), 'created_at desc'], [t('.oldest'), 'created_at asc']], params[:q]&.dig(:s)), {}, { class: "select select-bordered" } %>
+
+      <%= form.label :habit_habit_type_eq, t('.habit_type'), class: "mr-2 ml-4" %>
+      <%= form.select :habit_habit_type_eq, options_for_select([[t('.all'), ''], [t('.good'), 'good'], [t('.bad'), 'bad']], params[:q]&.dig(:habit_habit_type_eq)), {}, { class: "select select-bordered" } %>
+
+      <%= form.label :reward_name_cont, t('.search_by_name'), class: "mr-2 ml-4" %>
+      <%= form.text_field :reward_name_cont, value: params[:q]&.dig(:reward_name_cont), class: "input input-bordered" %>
+
+      <%= form.submit t('.filter'), class: "btn btn-primary ml-4" %>
+    <% end %>
   </div>
 
   <div class="list">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -162,11 +162,20 @@ ja:
       back: "すべての報酬に戻る"
   user_rewards:
     index:
-      heading: "あなたの獲得報酬一覧"
-      all_rewards: "獲得可能報酬"
+      heading: "あなたの報酬"
+      all_rewards: "全ての報酬を見る"
+      sort_by: "並び替え"
+      newest: "新着順"
+      oldest: "古い順"
+      habit_type: "習慣タイプ"
+      all: "すべて"
+      good: "良い"
+      bad: "悪い"
+      search_by_name: "検索"
+      filter: "フィルタ"
       habit: "習慣"
       habit_type: "習慣タイプ"
-      completed_on: "達成日"
+      completed_on: "獲得日"
   public_rewards:
     index:
       heading: "みんなの獲得報酬一覧"


### PR DESCRIPTION
### 概要

このプルリクエストでは、ユーザーが獲得した報酬一覧（`user_rewards#index`）ページにソート機能と検索機能を追加しました。

### 変更内容

1. **ソート機能の追加**
   - 報酬の獲得日でソートできるようにしました。新着順（デフォルト）と古い順のオプションがあります。

2. **検索機能の追加**
   - 報酬名で検索できるようにしました。
   - 習慣タイプ（良い習慣/悪い習慣）でフィルタリングできるようにしました。

### 技術的変更点

- `user_rewards_controller.rb`を更新し、Ransackを利用した検索とソート機能を実装しました。
- ビューのフォームに検索とソートのためのフィールドを追加しました。
- `HabitReward`モデルに`ransackable_attributes`および`ransackable_associations`メソッドを追加し、Ransackの検索対象とする属性および関連を指定しました。

### 関連するIssue
- Issue #84 
