### PR TITLE
【feature】獲得報酬カードのUI改善

### DIFF
--- a/app/views/public_rewards/index.html.erb
+++ b/app/views/public_rewards/index.html.erb
@@ -4,7 +4,7 @@
   <div class="mb-4 flex items-center">
     <%= search_form_for @q, url: public_rewards_path, method: :get, class: "flex items-center space-x-2" do |form| %>
       <div>
-        <%= form.label :s, t('.sort_by'), class: "mr-2" %>
+        <%= form.label :s, t('.sort_by'), class: "mr-2 ml-4" %>
         <%= form.select :s, options_for_select([[t('.newest'), 'created_at desc'], [t('.oldest'), 'created_at asc']], params[:q]&.dig(:s)), {}, { class: "select select-bordered" } %>
       </div>
       <div>
@@ -16,23 +16,14 @@
         <%= form.text_field :reward_name_cont, value: params[:q]&.dig(:reward_name_cont), class: "input input-bordered" %>
       </div>
       <div>
-        <%= form.submit t('.filter'), class: "btn btn-primary ml-4" %>
+        <%= form.submit t('.filter'), class: "btn btn-primary mr-2 ml-4" %>
       </div>
     <% end %>
   </div>
 
   <div class="list">
     <% @habit_rewards.each do |habit_reward| %>
-      <div class="card bg-base-100 shadow-xl my-3">
-        <div class="card-body">
-          <h3 class="text-xl font-bold leading-6 text-gray-900"><%= habit_reward.reward.name %></h3>
-          <p class="text-gray-700"><%= habit_reward.reward.description %></p>
-          <p class="text-gray-500"><%= t('.habit') %>: <%= habit_reward.habit.name %></p>
-          <p class="text-gray-500"><%= t('.habit_type') %>: <%= habit_reward.habit.habit_type.humanize %></p>
-          <p class="text-gray-500"><%= t('.user') %>: <%= habit_reward.habit.user.username %></p>
-          <p class="text-gray-500"><%= t('.completed_on') %>: <%= habit_reward.created_at.strftime("%Y-%m-%d") %></p>
-        </div>
-      </div>
+      <%= render partial: 'shared/reward_card', locals: { reward: habit_reward.reward, habit_reward: habit_reward } %>
     <% end %>
   </div>
 

--- a/app/views/shared/_reward_card.html.erb
+++ b/app/views/shared/_reward_card.html.erb
@@ -1,0 +1,21 @@
+<% color_class = habit_reward.habit.habit_type == 'good' ? 'bg-yellow-100' : 'bg-purple-100' %>
+<div class="card bg-base-100 shadow-xl my-5 <%= color_class %>">
+  <div class="card-body">
+    <div class="text-gray-500">
+      <strong><%= habit_reward.habit.user.username %></strong>
+    </div>
+
+    <div>
+      <p class="text-gray-500"><%= habit_reward.habit.name %></p>
+    </div>
+
+    <div>
+      <% color_class = habit_reward.habit.habit_type == 'good' ? 'text-yellow-600' : 'text-purple-600' %>
+      <h2 class="card-title <%= color_class %>"><%= habit_reward.reward.name %></h2>
+    </div>
+
+    <p class="text-gray-500"><%= habit_reward.reward.description %></p>
+
+    <p class="text-gray-500"><%= t('.completed_on') %>: <%= habit_reward.created_at.strftime("%Y-%m-%d") %></p>
+  </div>
+</div>

--- a/app/views/user_rewards/index.html.erb
+++ b/app/views/user_rewards/index.html.erb
@@ -3,30 +3,27 @@
 
   <div class="mb-4 flex items-center">
     <%= search_form_for @q, url: user_rewards_path, method: :get, local: true, class: "flex items-center space-x-2" do |form| %>
+    <div>
       <%= form.label :s, t('.sort_by'), class: "mr-2 ml-4" %>
       <%= form.select :s, options_for_select([[t('.newest'), 'created_at desc'], [t('.oldest'), 'created_at asc']], params[:q]&.dig(:s)), {}, { class: "select select-bordered" } %>
-
+    </div>
+    <div>
       <%= form.label :habit_habit_type_eq, t('.habit_type'), class: "mr-2 ml-4" %>
       <%= form.select :habit_habit_type_eq, options_for_select([[t('.all'), ''], [t('.good'), 'good'], [t('.bad'), 'bad']], params[:q]&.dig(:habit_habit_type_eq)), {}, { class: "select select-bordered" } %>
-
+    </div>
+    <div>
       <%= form.label :reward_name_cont, t('.search_by_name'), class: "mr-2 ml-4" %>
       <%= form.text_field :reward_name_cont, value: params[:q]&.dig(:reward_name_cont), class: "input input-bordered" %>
-
-      <%= form.submit t('.filter'), class: "btn btn-primary ml-4" %>
+    </div>
+    <div>
+      <%= form.submit t('.filter'), class: "btn btn-primary mr-2 ml-4" %>
+    </div>
     <% end %>
   </div>
 
   <div class="list">
     <% @user_rewards.each do |habit_reward| %>
-      <div class="card bg-base-100 shadow-xl my-3">
-        <div class="card-body">
-          <h3 class="text-xl font-bold leading-6 text-gray-900"><%= habit_reward.reward.name %></h3>
-          <p class="text-gray-700"><%= habit_reward.reward.description %></p>
-          <p class="text-gray-500"><%= t('.habit') %>: <%= habit_reward.habit.name %></p>
-          <p class="text-gray-500"><%= t('.habit_type') %>: <%= habit_reward.habit.habit_type.humanize %></p>
-          <p class="text-gray-500"><%= t('.completed_on') %>: <%= habit_reward.created_at.strftime("%Y-%m-%d") %></p>
-        </div>
-      </div>
+      <%= render partial: 'shared/reward_card', locals: { reward: habit_reward.reward, habit_reward: habit_reward } %>
     <% end %>
   </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,12 @@ ja:
       update: 更新
       complete: "達成"
       not_complete: "未達成"
+  shared:
+    reward_card:
+      habit: "習慣"
+      habit_type: "習慣タイプ"
+      user: "ユーザー"
+      completed_on: "達成日"
   users:
     form:
       errors:
@@ -172,7 +178,7 @@ ja:
       good: "良い"
       bad: "悪い"
       search_by_name: "習慣名"
-      filter: "フィルタ"
+      filter: "フィルター"
       habit: "習慣"
       habit_type: "習慣タイプ"
       completed_on: "獲得日"


### PR DESCRIPTION
### 概要

このプルリクエストでは、以下のUI改善を実施しました。
1. 獲得報酬カードのパーシャル化
2. 獲得報酬カードのレイアウト整理

### 変更内容

- 獲得報酬カードの共通部分をパーシャル `_reward_card.html.erb` に移動し、再利用性を高めました。
- `user_rewards#index` と `public_rewards#index` のビューで新しいパーシャルを使用するように修正しました。
- 獲得報酬カードのUIを改善し、以下のレイアウト整理を行いました。
  - ユーザー名、習慣名、報酬名、説明、習慣タイプ、獲得日を表示。
  - 良い習慣と悪い習慣の区別がつきやすいように、カードの背景色を変更。
  - レイアウト全体の見た目を統一。

### 変更ファイル

- `app/views/shared/_reward_card.html.erb`:
  - 獲得報酬カードのパーシャルを新規作成。

- `app/views/user_rewards/index.html.erb`:
  - 獲得報酬カードの表示部分をパーシャル化。

- `app/views/public_rewards/index.html.erb`:
  - 獲得報酬カードの表示部分をパーシャル化。

### 関連するIssue

- Issue #85 
