### PR TITLE
【feature】獲得報酬のモーダル表示機能の実装

### DIFF
--- a/app/controllers/habit_logs_controller.rb
+++ b/app/controllers/habit_logs_controller.rb
@@ -24,14 +24,17 @@ class HabitLogsController < ApplicationController
 
   def update
     if @habit_log.update(habit_log_params)
+      rewards = @habit_log.habit.check_and_apply_rewards
       flash.now[:success] = t('habit_logs.update.success')
+
       respond_to do |format|
         format.html { redirect_to determine_redirect_target }
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace("flash", partial: "shared/flash_message"),
-            turbo_stream.replace("habit_log_#{@habit_log.id}", partial: "shared/habit_log", locals: { habit_log: @habit_log })
-          ]
+            turbo_stream.replace("habit_log_#{@habit_log.id}", partial: "shared/habit_log", locals: { habit_log: @habit_log }),
+            (rewards.present? ? turbo_stream.replace("modal", partial: "shared/reward_modal", locals: { reward: rewards.last }) : nil)
+          ].compact
         end
       end
     else

--- a/app/controllers/user_rewards_controller.rb
+++ b/app/controllers/user_rewards_controller.rb
@@ -10,7 +10,9 @@ class UserRewardsController < ApplicationController
     @habit_reward = HabitReward.find(params[:id])
     respond_to do |format|
       format.html
-      format.turbo_stream { render partial: 'shared/reward_modal', locals: { reward: @habit_reward.reward } }
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace('modal', partial: 'shared/reward_modal', locals: { reward: @habit_reward })
+      end
     end
   end
 end

--- a/app/controllers/user_rewards_controller.rb
+++ b/app/controllers/user_rewards_controller.rb
@@ -5,4 +5,12 @@ class UserRewardsController < ApplicationController
                     .ransack(params[:q])
     @user_rewards = @q.result.order(created_at: :desc).page(params[:page])
   end
+
+  def show
+    @habit_reward = HabitReward.find(params[:id])
+    respond_to do |format|
+      format.html
+      format.turbo_stream { render partial: 'shared/reward_modal', locals: { reward: @habit_reward.reward } }
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,4 +26,9 @@ module ApplicationHelper
       }
     }
   end
+
+  def share_message(habit_name, reward_name)
+    message = "習慣［#{habit_name}］が 報酬［#{reward_name}］を達成しました！\n#LockAway\n"
+    URI.encode_www_form_component(message)
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,5 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="modal"
 export default class extends Controller {
   connect() {
+    this.showModal()
+  }
+
+  showModal() {
+    this.element.showModal()
+  }
+
+  close() {
+    this.element.close()
   }
 }

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -53,14 +53,22 @@ class Habit < ApplicationRecord
   end
 
   def check_and_apply_rewards
+    acquired_rewards = []
     Reward.where(habit_type: self.habit_type).each do |reward|
       case reward.condition_type
       when 'continuous_days'
-        apply_reward(reward) if continuous_completed_days >= reward.threshold
+        if continuous_completed_days >= reward.threshold
+          apply_reward(reward)
+          acquired_rewards << reward
+        end
       when 'total_days'
-        apply_reward(reward) if total_completed_days >= reward.threshold
+        if total_completed_days >= reward.threshold
+          apply_reward(reward)
+          acquired_rewards << reward
+        end
       end
     end
+    acquired_rewards
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,8 @@
 
     <%= yield %>
 
+    <%= turbo_frame_tag 'modal' %>
+
     <%= render 'shared/footer' %>
   </body>
 

--- a/app/views/shared/_reward_card.html.erb
+++ b/app/views/shared/_reward_card.html.erb
@@ -8,7 +8,7 @@
       <%= link_to t('.show'), user_reward_path(habit_reward), class: 'btn btn-info text-white btn-xs', data: { turbo_frame: 'modal' } %>
       <% if current_user == habit_reward.habit.user %>
         <div class="flex-none mx-5">
-          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=【#{habit_reward.habit.name}】が【#{habit_reward.reward.name}】を達成しました！", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white btn-xs" %>
+          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=#{share_message(habit_reward.habit.name, habit_reward.reward.name)}", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white btn-xs" %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_reward_card.html.erb
+++ b/app/views/shared/_reward_card.html.erb
@@ -5,7 +5,7 @@
       <div class="flex-1 text-gray-500">
         <strong><%= habit_reward.habit.user.username %></strong>
       </div>
-      <%= link_to "show reward", user_reward_path(habit_reward), class: 'btn btn-info text-white btn-xs', data: { turbo_frame: 'modal' } %>
+      <%= link_to t('.show'), user_reward_path(habit_reward), class: 'btn btn-info text-white btn-xs', data: { turbo_frame: 'modal' } %>
       <% if current_user == habit_reward.habit.user %>
         <div class="flex-none mx-5">
           <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=【#{habit_reward.habit.name}】が【#{habit_reward.reward.name}】を達成しました！", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white btn-xs" %>

--- a/app/views/shared/_reward_card.html.erb
+++ b/app/views/shared/_reward_card.html.erb
@@ -5,6 +5,7 @@
       <div class="flex-1 text-gray-500">
         <strong><%= habit_reward.habit.user.username %></strong>
       </div>
+      <%= link_to "show reward", user_reward_path(habit_reward), class: 'btn btn-info text-white btn-xs', data: { turbo_frame: 'modal' } %>
       <% if current_user == habit_reward.habit.user %>
         <div class="flex-none mx-5">
           <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=【#{habit_reward.habit.name}】が【#{habit_reward.reward.name}】を達成しました！", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white btn-xs" %>

--- a/app/views/shared/_reward_modal.html.erb
+++ b/app/views/shared/_reward_modal.html.erb
@@ -1,11 +1,38 @@
 <%= turbo_frame_tag 'modal' do %>
+  <% color_class = reward.habit.habit_type == 'good' ? 'bg-yellow-100' : 'bg-purple-100' %>
   <dialog id="my_modal" class="modal modal-bottom sm:modal-middle" data-controller="modal">
-    <div class="modal-box">
-      <h3 class="text-lg font-bold"><%= reward.name %></h3>
-      <p class="py-4"><%= reward.description %></p>
+    <div class="modal-box text-center <%= color_class %>">
       <div class="modal-action">
-        <button class="btn" data-action="modal#close">Close</button>
+        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-action="modal#close"><%= t('.close') %></button>
       </div>
+
+      <div class="text-gray-500 text-xl mb-3">
+        <strong><%= t('.title') %></strong>
+      </div>
+
+      <div class="my-5">
+        <% color_class = reward.habit.habit_type == 'good' ? 'text-yellow-600' : 'text-purple-600' %>
+        <h2 class="text-2xl font-bold leading-6 <%= color_class %>"><%= reward.reward.name %></h2>
+      </div>
+
+      <div class="text-gray-500 my-2">
+        <p><%= reward.habit.user.username %></p>
+      </div>
+
+      <div class="my-2">
+        <p class="text-gray-500"><%= reward.habit.name %></p>
+      </div>
+
+      <div class="my-2">
+        <p class="text-gray-700"><%= reward.reward.description %></p>
+        <p class="text-gray-500"><%= t('.completed_on') %>: <%= reward.created_at.strftime("%Y-%m-%d") %></p>
+      </div>
+
+      <% if current_user == reward.habit.user %>
+        <div class="flex-none mx-5">
+          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=習慣［#{reward.habit.name}］が［#{reward.reward.name}］を達成しました！%0a%0a", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white mt-5 mb-5" %>
+        </div>
+      <% end %>
     </div>
   </dialog>
 <% end %>

--- a/app/views/shared/_reward_modal.html.erb
+++ b/app/views/shared/_reward_modal.html.erb
@@ -30,7 +30,7 @@
 
       <% if current_user == reward.habit.user %>
         <div class="flex-none mx-5">
-          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=習慣［#{reward.habit.name}］が［#{reward.reward.name}］を達成しました！%0a%0a", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white mt-5 mb-5" %>
+          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=#{share_message(reward.habit.name, reward.reward.name)}", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white mt-5 mb-5" %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_reward_modal.html.erb
+++ b/app/views/shared/_reward_modal.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag 'modal' do %>
+  <dialog id="my_modal" class="modal modal-bottom sm:modal-middle" data-controller="modal">
+    <div class="modal-box">
+      <h3 class="text-lg font-bold"><%= reward.name %></h3>
+      <p class="py-4"><%= reward.description %></p>
+      <div class="modal-action">
+        <button class="btn" data-action="modal#close">Close</button>
+      </div>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/user_rewards/show.html.erb
+++ b/app/views/user_rewards/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'shared/reward_modal', locals: { reward: @habit_reward.reward } %>

--- a/app/views/user_rewards/show.html.erb
+++ b/app/views/user_rewards/show.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'shared/reward_modal', locals: { reward: @habit_reward.reward } %>
+<%= render partial: 'shared/reward_modal', locals: { reward: @habit_reward } %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,11 @@ ja:
       habit_type: "習慣タイプ"
       user: "ユーザー"
       completed_on: "達成日"
+      show: "詳細"
+    reward_modal:
+      title: "報酬を獲得しました！"
+      completed_on: "達成日"
+      close: "✕"
   users:
     form:
       errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
 
   resources :unlogged_habit_logs, only: [:index]
 
-  resources :user_rewards, only: [:index]
+  resources :user_rewards, only: [:index, :show]
 
   resources :users
 


### PR DESCRIPTION
### 概要

このプルリクエストでは、ユーザーが習慣ログを記録した際に獲得した報酬をモーダルで表示する機能を追加しました。
また、獲得報酬一覧ページ（user_rewards#index）から報酬の詳細をモーダルで表示できるようにしました。

### 変更内容

1. **モーダルの実装**
   - 獲得報酬をモーダルで表示するためのビューを追加しました。
   - `stimulus`を用いてモーダルの表示と閉じる機能を実装しました。

2. **報酬の詳細表示**
   - `user_rewards#show`アクションを追加し、モーダルで報酬の詳細を表示できるようにしました。
   - モーダルで表示される内容には、報酬名、報酬の説明、習慣の名前、ユーザー名、達成日が含まれます。

3. **シェアボタンの統一**
   - モーダルおよび報酬カードのシェアボタンの投稿内容を統一しました。
   - `application_helper.rb`にヘルパーメソッド`share_message`を追加し、シェア内容を統一して管理できるようにしました。

### 関連するIssue

- Issue #83 
