### PR TITLE
【fix】`PublicHabits#show`のルート処理修正 および 戻るボタンのナビゲーション改善

### DIFF
--- a/app/views/habits/edit.html.erb
+++ b/app/views/habits/edit.html.erb
@@ -4,6 +4,6 @@
   <%= render 'form', habit: @habit, button_text: t('helpers.submit.update') %>
 
   <div class="mt-5 mb-10">
-    <%= link_to t('.back'), habits_path, class: "btn btn-primary btn-outline w-full" %>
+    <%= link_to t('.back'), request.referer || habits_path, class: "btn btn-primary btn-outline w-full" %>
   </div>
 </div>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -81,6 +81,6 @@
 
   <div class="flex mt-5 mb-10">
     <%= link_to t('.edit'), edit_habit_path(@habit), class: 'btn btn-secondary flex-auto w-full mr-2' %>
-    <%= link_to t('.back'), habits_path, class: 'btn btn-primary btn-outline flex-auto w-full ml-2' %>
+    <%= link_to t('.back'), request.referer || habits_path, class: 'btn btn-primary btn-outline flex-auto w-full ml-2' %>
   </div>
 </div>

--- a/app/views/shared/_habit_card.html.erb
+++ b/app/views/shared/_habit_card.html.erb
@@ -6,7 +6,11 @@
         <strong><%= habit.user.username %></strong>
       </div>
       <div class="flex-none">
-        <%= link_to t('habits.show.show'), show_path, class: 'btn btn-info text-white btn-xs' %>
+        <% if current_user&.own?(habit) %>
+          <%= link_to t('habits.show.show'), habit_path(habit), class: 'btn btn-info text-white btn-xs' %>
+        <% else %>
+          <%= link_to t('habits.show.show'), public_habit_path(habit), class: 'btn btn-info text-white btn-xs' %>
+        <% end %>
         <% if editable %>
           <%= link_to t('habits.show.edit'), edit_path, id: "button-edit-#{habit.id}", class: 'btn btn-warning text-white btn-xs' %>
           <%= link_to t('habits.show.delete'), delete_path, id: "button-delete-#{habit.id}", data: { turbo_method: :delete, turbo_confirm: t('habits.show.are_you_sure') }, class: 'btn btn-error text-white btn-xs' %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -128,14 +128,14 @@ ja:
       show: "詳細"
       edit: "編集"
       delete: "削除"
-      back: "習慣一覧に戻る"
+      back: "一覧に戻る"
       are_you_sure: "本当に削除しますか？"
     new:
       heading: "新しい習慣"
-      back: "習慣一覧に戻る"
+      back: "戻る"
     edit:
       heading: "習慣の編集"
-      back: "習慣一覧に戻る"
+      back: "一覧に戻る"
     create:
       success: "習慣が正常に作成されました。"
       failure: "習慣を作成できませんでした。"
@@ -200,7 +200,7 @@ ja:
       heading: "報酬詳細"
       habit_type: "習慣タイプ"
       condition: "条件"
-      back: "報酬一覧に戻る"
+      back: "一覧に戻る"
     available:
       heading: "利用可能な報酬"
       progress: "進行状況: %{progress} / %{threshold} 日"


### PR DESCRIPTION
### 概要

- `PublicHabits#index`からユーザー自身の習慣の詳細ページに遷移する際に、`Habits#show`を表示するように修正しました。
- `shared/_habit_card.html.erb`で、ユーザー自身の習慣かどうかに応じて、詳細ページのリンクを動的に設定する処理を追加しました。
- `Habits#show`ページおよび`Habits#edit`ページでの「戻る」ボタンに、`request.referer`を利用した動的な戻り先の設定を追加しました。これにより、ユーザーがどのページから来たかに応じて適切なページに戻ることができます。

### 修正内容

1. `shared/_habit_card.html.erb`:
   - ユーザーの習慣かどうかを判定し、適切な`show_path`を動的に設定。

2. `habits/show.html.erb`:
   - `request.referer`を利用して「戻る」ボタンのリンク先を動的に設定。

3. `habits/edit.html.erb`:
   - `request.referer`を利用して「戻る」ボタンのリンク先を動的に設定。
