### PR TITLE
【fix】連続完了日数表示の修正と報酬モーダルのエラー修正

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -3,11 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="modal"
 export default class extends Controller {
   connect() {
+    console.log("Modal connected")
     this.showModal()
   }
 
   showModal() {
-    this.element.showModal()
+    if (this.element.tagName === "DIALOG") {
+      this.element.showModal()
+    }
   }
 
   close() {

--- a/app/views/shared/_reward_modal.html.erb
+++ b/app/views/shared/_reward_modal.html.erb
@@ -1,38 +1,42 @@
 <%= turbo_frame_tag 'modal' do %>
-  <% color_class = reward.habit.habit_type == 'good' ? 'bg-yellow-100' : 'bg-purple-100' %>
-  <dialog id="my_modal" class="modal modal-bottom sm:modal-middle" data-controller="modal">
-    <div class="modal-box text-center <%= color_class %>">
-      <div class="modal-action">
-        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-action="modal#close"><%= t('.close') %></button>
-      </div>
-
-      <div class="text-gray-500 text-xl mb-3">
-        <strong><%= t('.title') %></strong>
-      </div>
-
-      <div class="my-5">
-        <% color_class = reward.habit.habit_type == 'good' ? 'text-yellow-600' : 'text-purple-600' %>
-        <h2 class="text-2xl font-bold leading-6 <%= color_class %>"><%= reward.reward.name %></h2>
-      </div>
-
-      <div class="text-gray-500 my-2">
-        <p><%= reward.habit.user.username %></p>
-      </div>
-
-      <div class="my-2">
-        <p class="text-gray-500"><%= reward.habit.name %></p>
-      </div>
-
-      <div class="my-2">
-        <p class="text-gray-700"><%= reward.reward.description %></p>
-        <p class="text-gray-500"><%= t('.completed_on') %>: <%= reward.created_at.strftime("%Y-%m-%d") %></p>
-      </div>
-
-      <% if current_user == reward.habit.user %>
-        <div class="flex-none mx-5">
-          <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=#{share_message(reward.habit.name, reward.reward.name)}", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white mt-5 mb-5" %>
+  <% if reward.present? && reward.habit.present? %>
+    <% color_class = reward.habit.habit_type == 'good' ? 'bg-yellow-100' : 'bg-purple-100' %>
+    <dialog id="my_modal" class="modal modal-bottom sm:modal-middle" data-controller="modal">
+      <div class="modal-box text-center <%= color_class %>">
+        <div class="modal-action">
+          <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-action="modal#close"><%= t('.close') %></button>
         </div>
-      <% end %>
-    </div>
-  </dialog>
+
+        <div class="text-gray-500 text-xl mb-3">
+          <strong><%= t('.title') %></strong>
+        </div>
+
+        <div class="my-5">
+          <% color_class = reward.habit.habit_type == 'good' ? 'text-yellow-600' : 'text-purple-600' %>
+          <h2 class="text-2xl font-bold leading-6 <%= color_class %>"><%= reward.reward.name %></h2>
+        </div>
+
+        <div class="text-gray-500 my-2">
+          <p><%= reward.habit.user.username %></p>
+        </div>
+
+        <div class="my-2">
+          <p class="text-gray-500"><%= reward.habit.name %></p>
+        </div>
+
+        <div class="my-2">
+          <p class="text-gray-700"><%= reward.reward.description %></p>
+          <p class="text-gray-500"><%= t('.completed_on') %>: <%= reward.created_at.strftime("%Y-%m-%d") %></p>
+        </div>
+
+        <% if current_user == reward.habit.user %>
+          <div class="flex-none mx-5">
+            <%= link_to t('helpers.twitter.share'), "https://twitter.com/intent/tweet?url=#{request.original_url}&text=#{share_message(reward.habit.name, reward.reward.name)}", target: "_blank", rel: "noopener", class: "btn btn-neutral text-white mt-5 mb-5" %>
+          </div>
+        <% end %>
+      </div>
+    </dialog>
+  <% else %>
+    <p class="text-center text-gray-500"><%= t('shared.reward_modal.no_habit') %></p>
+  <% end %>
 <% end %>


### PR DESCRIPTION
### 概要

- 連続完了日数が正しく表示されない問題を修正しました。
- 報酬取得時にモーダルが正しく表示されない問題を修正しました。

### 変更内容

1. **連続完了日数表示の修正**:
   - 記録が欠けている場合や未完了の習慣ログが存在する場合、それまでの連続完了日数のみが正しく表示されるように、`Habit`モデルの`continuous_completed_days`メソッドを修正しました。

2. **報酬モーダルのエラー修正**:
   - `HabitLogsController#update`で報酬取得後にモーダルが表示されない問題を修正しました。
   - `check_and_apply_rewards`メソッドのロジックを見直し、報酬適用後に正しい`HabitReward`オブジェクトが返されるように修正しました。
   - モーダルの部分テンプレートにおいて、`HabitReward`オブジェクトが正しく設定されていない場合のエラーハンドリングを追加しました。
   - JavaScriptの`modal_controller.js`において、`showModal()`が確実に呼び出されるよう改善しました。

### 関連する Issue

- Issue #114 
