### PR TITLE
【feature】未記録の習慣ログ一覧のUI改善

### DIFF
--- a/app/controllers/habit_logs_controller.rb
+++ b/app/controllers/habit_logs_controller.rb
@@ -24,7 +24,10 @@ class HabitLogsController < ApplicationController
 
   def update
     if @habit_log.update(habit_log_params)
-      rewards = @habit_log.habit.check_and_apply_rewards
+      # 更新されたログに関連する報酬を取得
+      applied_rewards = @habit_log.habit.check_and_apply_rewards
+      newly_acquired_reward = applied_rewards.find { |reward| reward.created_at >= @habit_log.updated_at }
+
       flash.now[:success] = t('habit_logs.update.success')
 
       respond_to do |format|
@@ -33,7 +36,7 @@ class HabitLogsController < ApplicationController
           render turbo_stream: [
             turbo_stream.replace("flash", partial: "shared/flash_message"),
             turbo_stream.replace("habit_log_#{@habit_log.id}", partial: "shared/habit_log", locals: { habit_log: @habit_log }),
-            (rewards.present? ? turbo_stream.replace("modal", partial: "shared/reward_modal", locals: { reward: rewards.last }) : nil)
+            (newly_acquired_reward.present? ? turbo_stream.replace("modal", partial: "shared/reward_modal", locals: { reward: newly_acquired_reward }) : nil)
           ].compact
         end
       end

--- a/app/controllers/unlogged_habit_logs_controller.rb
+++ b/app/controllers/unlogged_habit_logs_controller.rb
@@ -2,5 +2,6 @@ class UnloggedHabitLogsController < ApplicationController
   def index
     @unlogged_habit_logs = HabitLog.joins(:habit)
                                    .where(habits: { user_id: current_user.id }, status: nil)
+                                   .order('habits.created_at DESC, date DESC')
   end
 end

--- a/app/views/habit_logs/index.html.erb
+++ b/app/views/habit_logs/index.html.erb
@@ -6,9 +6,12 @@
     <table class="table">
       <thead>
         <tr>
-          <th><%= t('.habit_name') %></th>
-          <th><%= t('.date') %></th>
-          <th><%= t('.status') %></th>
+          <th>
+            <div class="text-center"><%= t('.date') %></div>
+          </th>
+          <th>
+            <div class="text-center"><%= t('.status') %></div>
+          </th>
         </tr>
       </thead>
       <tbody>

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -1,9 +1,11 @@
 <div class="container mx-auto w-full max-w-2xl">
-  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.heading') %></h2>
+  <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 mx-5"><%= t('.heading') %></h2>
 
-  <%= render 'form', habit: @habit, button_text: t('helpers.submit.create') %>
+  <div class="mx-5">
+    <%= render 'form', habit: @habit, button_text: t('helpers.submit.create') %>
 
-  <div class="mt-5 mb-10">
-    <%= link_to t('.back'), habits_path, class: "btn btn-primary btn-outline w-full" %>
+    <div class="mt-5 mb-10">
+      <%= link_to t('.back'), habits_path, class: "btn btn-primary btn-outline w-full" %>
+    </div>
   </div>
 </div>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -95,9 +95,12 @@
           <table class="table">
             <thead>
               <tr>
-                <th><%= t('habit_logs.index.habit_name') %></th>
-                <th><%= t('habit_logs.index.date') %></th>
-                <th><%= t('habit_logs.index.status') %></th>
+                <th>
+                  <div class="text-center"><%= t('habit_logs.index.date') %></div>
+                </th>
+                <th>
+                  <div class="text-center"><%= t('habit_logs.index.status') %></div>
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/app/views/shared/_habit_card.html.erb
+++ b/app/views/shared/_habit_card.html.erb
@@ -26,13 +26,13 @@
       </div>
     </div>
     <div class="flex items-center mx-3">
-      <div class="badge badge-outline w-24 px-5 mr-5">
+      <div class="badge badge-outline w-20 px-3 mr-5">
         <%= t('habits.show.description') %>
       </div>
       <%= habit.description %>
     </div>
     <div class="flex items-center mx-3">
-      <div class="badge badge-outline w-24 px-5 mr-5">
+      <div class="badge badge-outline w-20 px-3 mr-5">
         <%= t('habits.show.start_date') %>
       </div>
       <%= habit.start_date.strftime("%Y-%m-%d") %>
@@ -41,18 +41,18 @@
     <% color_class = habit.habit_type == 'good' ? 'text-yellow-400' : 'text-purple-400' %>
     <div class="stats stats-vertical lg:stats-horizontal shadow w-full mt-3 text-center">
       <div class="stat flex items-center">
-        <div class="stat-title flex-1"><%= t('habits.show.continuous_completed_days') %>:</div>
-        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= habit.continuous_completed_days %></div>
+        <div class="stat-title basis-2/3"><%= t('habits.show.continuous_completed_days') %>:</div>
+        <div class="stat-value basis-1/3 text-primary text-3xl <%= color_class %>"><%= habit.continuous_completed_days %></div>
       </div>
 
       <div class="stat flex items-center">
-        <div class="stat-title flex-1"><%= t('habits.show.highest_continuous_days') %>:</div>
-        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= habit.highest_continuous_days %></div>
+        <div class="stat-title basis-2/3"><%= t('habits.show.highest_continuous_days') %>:</div>
+        <div class="stat-value basis-1/3 text-primary text-3xl <%= color_class %>"><%= habit.highest_continuous_days %></div>
       </div>
 
       <div class="stat flex items-center">
-        <div class="stat-title flex-1"><%= t('habits.show.total_completed_days') %>:</div>
-        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= habit.total_completed_days %></div>
+        <div class="stat-title basis-2/3"><%= t('habits.show.total_completed_days') %>:</div>
+        <div class="stat-value basis-1/3 text-primary text-3xl <%= color_class %>"><%= habit.total_completed_days %></div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_habit_log.html.erb
+++ b/app/views/shared/_habit_log.html.erb
@@ -1,19 +1,37 @@
 <tr id="habit_log_<%= habit_log.id %>">
-  <td><%= habit_log.habit.name if habit_log.habit %></td>
-  <td><%= habit_log.date %></td>
   <td>
-    <div class="flex">
+    <div class="text-center"><%= habit_log.date %></div>
+  </td>
+  <td>
+    <div class="block md:flex justify-center text-center">
       <% if habit_log.status.nil? %>
-        <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
-          <%= form.hidden_field :status, value: 'completed' %>
-          <%= form.submit t('helpers.submit.complete'), class: 'btn btn-success btn-xs flex mx-1' %>
-        <% end %>
-        <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
-          <%= form.hidden_field :status, value: 'not_completed' %>
-          <%= form.submit t('helpers.submit.not_complete'), class: 'btn btn-error btn-xs flex mx-1' %>
+        <% if habit_log.habit.habit_type == 'good' %>
+          <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
+            <%= form.hidden_field :status, value: 'completed' %>
+            <%= form.submit t('helpers.submit.completed'), class: 'btn btn-ghost btn-xs bg-yellow-400 w-32 m-1' %>
+          <% end %>
+          <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
+            <%= form.hidden_field :status, value: 'not_completed' %>
+            <%= form.submit t('helpers.submit.not_completed'), class: 'btn btn-ghost btn-xs bg-yellow-200 w-32 m-1' %>
+          <% end %>
+        <% else %>
+          <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
+            <%= form.hidden_field :status, value: 'completed' %>
+            <%= form.submit t('helpers.submit.avoided'), class: 'btn btn-ghost btn-xs bg-purple-400 w-32 m-1' %>
+          <% end %>
+          <%= form_with(model: [habit_log.habit, habit_log], data: { turbo: true }, method: :patch) do |form| %>
+            <%= form.hidden_field :status, value: 'not_completed' %>
+            <%= form.submit t('helpers.submit.not_avoided'), class: 'btn btn-ghost btn-xs bg-purple-200 w-32 m-1' %>
+          <% end %>
         <% end %>
       <% else %>
-        <span><%= habit_log.status ? t("habit_logs.status.#{habit_log.status}") : '' %></span>
+        <% status_color_class = if habit_log.status == 'completed' %>
+          <% habit_log.habit.habit_type == 'good' ? 'text-amber-500' : 'text-fuchsia-500' %>
+        <% else %>
+          <% habit_log.habit.habit_type == 'good' ? 'text-amber-400' : 'text-fuchsia-400' %>
+        <% end %>
+
+        <span class="<%= status_color_class %> text-lg font-bold"><%= habit_log.status ? t("habit_logs.status.#{habit_log.status}") : '' %></span>
       <% end %>
     </div>
   </td>

--- a/app/views/unlogged_habit_logs/index.html.erb
+++ b/app/views/unlogged_habit_logs/index.html.erb
@@ -1,18 +1,33 @@
 <div class="container mx-auto w-full max-w-2xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('.heading') %></h2>
 
-  <table class="table">
-    <thead>
-      <tr>
-        <th><%= t('unlogged_habit_logs.index.habit_name') %></th>
-        <th><%= t('habit_logs.index.date') %></th>
-        <th><%= t('habit_logs.index.status') %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @unlogged_habit_logs.each do |log| %>
-        <%= render partial: 'shared/habit_log', locals: { habit_log: log } %>
-      <% end %>
-    </tbody>
-  </table>
+  <% @unlogged_habit_logs.group_by(&:habit).each do |habit, logs| %>
+    <% color_class = habit.habit_type == 'good' ? 'bg-yellow-50' : 'bg-purple-50' %>
+    <div class="card bg-base-100 shadow-xl mx-5 my-5 <%= color_class %>">
+      <div class="card-body">
+        <div class="flex justify-between items-center mb-3">
+          <h3 class="text-xl font-bold text-gray-900"><%= habit.name %></h3>
+          <%= link_to t('habits.show.show'), habit_path(habit), class: 'btn btn-info btn-sm text-white' %>
+        </div>
+
+        <table class="table">
+          <thead>
+            <tr>
+              <th>
+                <div class="text-center"><%= t('habit_logs.index.date') %></div>
+              </th>
+              <th>
+                <div class="text-center"><%= t('habit_logs.index.status') %></div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% logs.each do |log| %>
+              <%= render partial: 'shared/habit_log', locals: { habit_log: log } %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,10 @@ ja:
       update: 更新
       complete: "達成"
       not_complete: "未達成"
+      completed: "達成した"
+      not_completed: "達成できなかった"
+      avoided: "避けた"
+      not_avoided: "避けられなかった"
     twitter:
       share: "Xでシェア"
     messages:
@@ -126,8 +130,8 @@ ja:
       type: "種類"
       description: "説明"
       start_date: "開始日"
-      total_completed_days: "総完了日数"
-      continuous_completed_days: "連続完了日数"
+      total_completed_days: "総達成日数"
+      continuous_completed_days: "現在の連続日数"
       highest_continuous_days: "最高連続日数"
       completion_rate: "完了率"
       public_private: "公開/非公開"


### PR DESCRIPTION
### 概要

未記録の習慣ログをより見やすくするためのUI改善を行いました。また、習慣が新しい順に表示されるように修正しました。

### 変更内容

1. **未記録の習慣ログを習慣ごとにカード形式で表示**  
   - 習慣ごとにログをグループ化し、カード形式で表示しました。
   - 良い習慣と悪い習慣で背景色を変更しています（良い習慣: 黄色系、悪い習慣: 紫系）。

2. **習慣の新しい順に並べ替え**  
   - `Habit`の`created_at`を基準に新しい順で並べ、その中で未記録のログを表示します。

3. **習慣詳細画面へのリンクを追加**  
   - 各習慣のカード内に「詳細を見る」ボタンを追加しました。

4. **ログ記録のステータスボタンの色とテキストを習慣タイプに応じて変更**  
   - 良い習慣では「達成した」「達成できなかった」、悪い習慣では「避けた」「避けられなかった」と表示されるようにし、ボタンの色も変更しました。

5. **レイアウト調整**
   - `UnloggedHabitLogs#index`のレイアウト変更に伴い、`Habitlogs#index`および`Habits#show`の表示を調整。
   - 習慣カードのレイアウトを調整。
   - `Habits#new`のレイアウトを調整。

6. **報酬モーダル表示ロジックの調整**
   - 習慣ログの記録後に表示される報酬モーダルが、最後に獲得した報酬ではなく、今記録したログによって新たに獲得した報酬のみ表示されるように修正しました。

### 関連する Issue

- Issue #117 
