### PR TITLE
【feature】ボトムナビゲーションの追加とレイアウト調整、および PublicHabits#show のUI改善

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%= display_meta_tags(default_meta_tags) %>
   </head>
 
-  <body>
+  <body class="pb-16">
     <% if current_user&.admin? %>
       <%= render 'shared/admin_header' %>
     <% elsif logged_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,10 @@
     <%= turbo_frame_tag 'modal' %>
 
     <%= render 'shared/footer' %>
+
+    <% if logged_in? %>
+      <%= render 'shared/bottom_navigation' %>
+    <% end %>
   </body>
 
   <script>

--- a/app/views/public_habits/show.html.erb
+++ b/app/views/public_habits/show.html.erb
@@ -1,63 +1,93 @@
-<div class="container mx-auto w-full max-w-2xl">
+<div class="container mx-auto w-full max-w-3xl">
   <h2 class="my-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('habits.show.heading') %></h2>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.name') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.name %>
-    </div>
-  </p>
+  <div class="mx-5">
+    <div class="card bg-base-100 shadow my-5">
+      <div class="card-body">
+        <div class="flex items-center">
+          <div class="basis-1/4 text-center my-2 w-full block leading-6 text-gray-900">
+            <div class="badge badge-ghost w-24 mr-5">
+              <%= t('habits.show.name') %>
+            </div>
+          </div>
+          <div class="basis-3/4 my-2 w-full block font-medium leading-6 text-gray-900">
+            <%= @habit.name %>
+          </div>
+        </div>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.type') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.habit_type.humanize %>
-    </div>
-  </p>
+        <div class="flex items-center">
+          <div class="basis-1/4 text-center my-2 w-full block leading-6 text-gray-900">
+            <div class="badge badge-ghost w-24 mr-5">
+              <%= t('habits.show.type') %>
+            </div>
+          </div>
+          <div class="basis-3/4 my-2 w-full block font-medium leading-6 text-gray-900">
+            <%= @habit.habit_type.humanize %>
+          </div>
+        </div>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.description') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.description %>
-    </div>
-  </p>
+        <div class="flex items-center">
+          <div class="basis-1/4 text-center my-2 w-full block leading-6 text-gray-900">
+            <div class="badge badge-ghost w-24 mr-5">
+              <%= t('habits.show.description') %>
+            </div>
+          </div>
+          <div class="basis-3/4 my-2 w-full block font-medium leading-6 text-gray-900">
+            <%= @habit.description %>
+          </div>
+        </div>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.start_date') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.start_date.strftime("%Y-%m-%d") %>
-    </div>
-  </p>
+        <div class="flex items-center">
+          <div class="basis-1/4 text-center my-2 w-full block leading-6 text-gray-900">
+            <div class="badge badge-ghost w-24 mr-5">
+              <%= t('habits.show.start_date') %>
+            </div>
+          </div>
+          <div class="basis-3/4 my-2 w-full block font-medium leading-6 text-gray-900">
+            <%= @habit.start_date.strftime("%Y-%m-%d") %>
+          </div>
+        </div>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.total_completed_days') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.total_completed_days %>
+        <div class="flex items-center">
+          <div class="basis-1/4 text-center my-2 w-full block leading-6 text-gray-900">
+            <div class="badge badge-ghost w-24 mr-5">
+              <%= t('habits.show.public_private') %>
+            </div>
+          </div>
+          <div class="basis-3/4 my-2 w-full block font-medium leading-6 text-gray-900">
+            <%= @habit.public ? t('habits.show.public') : t('habits.show.private') %>
+          </div>
+        </div>
+      </div>
     </div>
-  </p>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.continuous_completed_days') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.continuous_completed_days %>
+    <% color_class = @habit.habit_type == 'good' ? 'text-yellow-400' : 'text-purple-400' %>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full my-3 text-center">
+      <div class="stat flex lg:block items-center">
+        <div class="stat-title flex-1"><%= t('habits.show.continuous_completed_days') %>:</div>
+        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= @habit.continuous_completed_days %></div>
+      </div>
+
+      <div class="stat flex lg:block items-center">
+        <div class="stat-title flex-1"><%= t('habits.show.highest_continuous_days') %>:</div>
+        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= @habit.highest_continuous_days %></div>
+      </div>
+
+      <div class="stat flex lg:block items-center">
+        <div class="stat-title flex-1"><%= t('habits.show.total_completed_days') %>:</div>
+        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= @habit.total_completed_days %></div>
+      </div>
+
+      <div class="stat flex lg:block items-center">
+        <div class="stat-title flex-1"><%= t('habits.show.completion_rate') %>:</div>
+        <div class="stat-value flex-1 text-primary text-3xl <%= color_class %>"><%= @habit.completion_rate %></div>
+      </div>
     </div>
-  </p>
+  </div>
 
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.completion_rate') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.completion_rate %>
+  <div class="mx-5">
+    <div class="mt-5 mb-10">
+      <%= link_to t('habits.show.back'), public_habits_path, class: "btn btn-primary btn-outline w-full" %>
     </div>
-  </p>
-
-  <p>
-    <strong class="my-2 w-full block leading-6 text-gray-900"><%= t('habits.show.public') %>:</strong>
-    <div class="my-2 w-full block font-medium leading-6 text-gray-900">
-      <%= @habit.public ? t('habits.show.yes') : t('habits.show.no') %>
-    </div>
-  </p>
-
-  <div class="flex mt-5 mb-10">
-    <%= link_to t('habits.show.back'), public_habits_path, class: 'btn btn-primary btn-outline flex-auto w-full ml-2' %>
   </div>
 </div>

--- a/app/views/shared/_admin_header.html.erb
+++ b/app/views/shared/_admin_header.html.erb
@@ -1,32 +1,6 @@
 <header>
   <div class="navbar bg-rose-100">
     <div class="navbar-start">
-      <!-- ハンバーガーメニュー -->
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-          <!-- ハンバーガーアイコン -->
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
-          </svg>
-        </div>
-        <!-- ハンバーガーメニューの内容 -->
-        <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li>
-            <%= link_to public_habits_path, class: "relative flex items-center" do %>
-              <%= render 'shared/public_habits_icon' %>
-              <%= t('header.public_habits') %>
-            <% end %>
-          </li>
-
-          <li>
-            <%= link_to public_rewards_path, class: "relative flex items-center" do %>
-              <%= render 'shared/public_rewards_icon' %>
-              <%= t('header.public_rewards') %>
-            <% end %>
-          </li>
-        </ul>
-      </div>
-
       <!-- サイトタイトル -->
       <%= link_to root_path, class: "btn btn-ghost text-xl" do %>
         <!-- 小さいスクリーン用 -->
@@ -38,18 +12,22 @@
 
     <div class="navbar-end flex items-center">
       <!-- 公開ページへのリンク -->
-      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_habits_icon' %>
-        <%= t('header.public_habits') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_habits') %>
+        </div>
       <% end %>
 
-      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_rewards_icon' %>
-        <%= t('header.public_rewards') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_rewards') %>
+        </div>
       <% end %>
 
       <!-- 新しい習慣作成ボタン -->
-      <%= link_to new_habit_path, class: "btn btn-ghost" do %>
+      <%= link_to new_habit_path, class: "hidden md:flex btn btn-ghost" do %>
         <%= render 'shared/new_habit_icon' %>
         <div class="hidden lg:flex">
           <%= t('header.new_habit') %>
@@ -57,7 +35,7 @@
       <% end %>
 
       <!-- 未記録の習慣通知ボタン -->
-      <%= link_to unlogged_habit_logs_path, class: "btn btn-ghost" do %>
+      <%= link_to unlogged_habit_logs_path, class: "hidden md:flex btn btn-ghost" do %>
         <%= render 'shared/unlogged_habit_logs_icon' %>
         <div class="hidden lg:flex">
           <%= t('header.unlogged_habit_logs') %>
@@ -66,7 +44,7 @@
 
       <!-- ユーザーのドロップダウンメニュー -->
       <div class="dropdown dropdown-end pl-3">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-circle text-rose-700">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
           <%= current_user.username %>
         </div>
         <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
@@ -75,14 +53,14 @@
           </li>
 
           <li>
-            <%= link_to habits_path, class: "relative flex items-center" do %>
+            <%= link_to habits_path, class: "hidden md:flex relative items-center" do %>
               <%= render 'shared/habits_icon' %>
               <%= t('header.your_habits') %>
             <% end %>
           </li>
 
           <li>
-            <%= link_to user_rewards_path do %>
+            <%= link_to user_rewards_path, class: "hidden md:flex relative items-center" do %>
               <%= render 'shared/user_rewards_icon' %>
               <%= t('header.your_rewards') %>
             <% end %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,21 +1,6 @@
 <header>
   <div class="navbar bg-base-100">
     <div class="navbar-start">
-      <!-- ハンバーガーメニュー -->
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-          <!-- ハンバーガーアイコン -->
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
-          </svg>
-        </div>
-        <!-- ハンバーガーメニューの内容 -->
-        <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li><%= link_to t('header.public_habits'), public_habits_path %></li>
-          <li><%= link_to t('header.public_rewards'), public_rewards_path %></li>
-        </ul>
-      </div>
-
       <!-- サイトタイトル -->
       <%= link_to root_path, class: "btn btn-ghost text-xl" do %>
         <!-- 小さいスクリーン用 -->
@@ -27,21 +12,23 @@
 
     <div class="navbar-end flex items-center">
       <!-- 公開ページへのリンク -->
-      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_habits_icon' %>
-        <%= t('header.public_habits') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_habits') %>
+        </div>
       <% end %>
 
-      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_rewards_icon' %>
-        <%= t('header.public_rewards') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_rewards') %>
+        </div>
       <% end %>
 
       <!-- ユーザー登録とログイン -->
-      <ul class="menu menu-horizontal px-1 flex">
-        <li><%= link_to t('header.signup'), new_user_path, class: "btn btn-secondary btn-xs md:btn-md" %></li>
-        <li><%= link_to t('header.login'), login_path, class: "btn btn-primary ml-2 btn-xs md:btn-md" %></li>
-      </ul>
+      <%= link_to t('header.signup'), new_user_path, class: "btn btn-secondary btn-xs md:btn-md" %>
+      <%= link_to t('header.login'), login_path, class: "btn btn-primary ml-2 btn-xs md:btn-md" %>
     </div>
   </div>
 </header>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,0 +1,17 @@
+<div class="btm-nav md:hidden items-center border border-slate-100">
+  <%= link_to new_habit_path, class: "" do %>
+    <%= render 'shared/new_habit_icon' %>
+  <% end %>
+
+  <%= link_to unlogged_habit_logs_path, class: "" do %>
+    <%= render 'shared/unlogged_habit_logs_icon' %>
+  <% end %>
+
+  <%= link_to habits_path, class: "" do %>
+    <%= render 'shared/habits_icon' %>
+  <% end %>
+
+  <%= link_to user_rewards_path, class: "" do %>
+    <%= render 'shared/user_rewards_icon' %>
+  <% end %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer footer-center bg-base-200 text-base-content p-5 mt-10">
+<footer class="hidden md:block footer footer-center bg-base-200 text-base-content p-5 mt-10">
   <div>
     <div class="flex items-center lg:flex-row">
       <div class="mb-4 lg:mb-0 mr-10">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,32 +1,6 @@
 <header>
   <div class="navbar bg-base-100">
     <div class="navbar-start">
-      <!-- ハンバーガーメニュー -->
-      <div class="dropdown">
-        <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-          <!-- ハンバーガーアイコン -->
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
-          </svg>
-        </div>
-        <!-- ハンバーガーメニューの内容 -->
-        <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
-          <li>
-            <%= link_to public_habits_path, class: "relative flex items-center" do %>
-              <%= render 'shared/public_habits_icon' %>
-              <%= t('header.public_habits') %>
-            <% end %>
-          </li>
-
-          <li>
-            <%= link_to public_rewards_path, class: "relative flex items-center" do %>
-              <%= render 'shared/public_rewards_icon' %>
-              <%= t('header.public_rewards') %>
-            <% end %>
-          </li>
-        </ul>
-      </div>
-
       <!-- サイトタイトル -->
       <%= link_to root_path, class: "btn btn-ghost text-xl" do %>
         <!-- 小さいスクリーン用 -->
@@ -38,18 +12,22 @@
 
     <div class="navbar-end flex items-center">
       <!-- 横並びのナビゲーションメニュー -->
-      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_habits_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_habits_icon' %>
-        <%= t('header.public_habits') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_habits') %>
+        </div>
       <% end %>
 
-      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost hidden lg:flex" do %>
+      <%= link_to public_rewards_path, class: "relative flex item-center btn btn-ghost" do %>
         <%= render 'shared/public_rewards_icon' %>
-        <%= t('header.public_rewards') %>
+        <div class="hidden lg:flex">
+          <%= t('header.public_rewards') %>
+        </div>
       <% end %>
 
       <!-- 新しい習慣作成ボタン -->
-      <%= link_to new_habit_path, class: "btn btn-ghost" do %>
+      <%= link_to new_habit_path, class: "hidden md:flex btn btn-ghost" do %>
         <%= render 'shared/new_habit_icon' %>
         <div class="hidden lg:flex">
           <%= t('header.new_habit') %>
@@ -57,7 +35,7 @@
       <% end %>
 
       <!-- 未記録の習慣通知ボタン -->
-      <%= link_to unlogged_habit_logs_path, class: "btn btn-ghost" do %>
+      <%= link_to unlogged_habit_logs_path, class: "hidden md:flex btn btn-ghost" do %>
         <%= render 'shared/unlogged_habit_logs_icon' %>
         <div class="hidden lg:flex">
           <%= t('header.unlogged_habit_logs') %>
@@ -71,14 +49,14 @@
         </div>
         <ul tabindex="0" class="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow">
           <li>
-            <%= link_to habits_path, class: "relative flex items-center" do %>
+            <%= link_to habits_path, class: "hidden md:flex relative items-center" do %>
               <%= render 'shared/habits_icon' %>
               <%= t('header.your_habits') %>
             <% end %>
           </li>
 
           <li>
-            <%= link_to user_rewards_path do %>
+            <%= link_to user_rewards_path, class: "hidden md:flex relative items-center" do %>
               <%= render 'shared/user_rewards_icon' %>
               <%= t('header.your_rewards') %>
             <% end %>

--- a/app/views/shared/_public_habits_icon.html.erb
+++ b/app/views/shared/_public_habits_icon.html.erb
@@ -1,10 +1,10 @@
 <div class="relative">
   <!-- メインのアイコン -->
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 text-orange-400">
     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
   </svg>
   <!-- 重ねるアイコン -->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4 absolute bottom-0 right-0 text-yellow-500">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4 absolute bottom-0 right-0 text-orange-500">
     <path d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z" />
   </svg>
 </div>

--- a/app/views/shared/_public_rewards_icon.html.erb
+++ b/app/views/shared/_public_rewards_icon.html.erb
@@ -1,10 +1,10 @@
 <div class="relative">
   <!-- メインのアイコン -->
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 text-orange-400">
     <path stroke-linecap="round" stroke-linejoin="round" d="M21 11.25v8.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5v-8.25M12 4.875A2.625 2.625 0 1 0 9.375 7.5H12m0-2.625V7.5m0-2.625A2.625 2.625 0 1 1 14.625 7.5H12m0 0V21m-8.625-9.75h18c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125h-18c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
   </svg>
   <!-- 重ねるアイコン -->
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4 absolute bottom-0 right-0 text-yellow-500">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4 absolute bottom-0 right-0 text-orange-500">
     <path d="M4.5 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM14.25 8.625a3.375 3.375 0 1 1 6.75 0 3.375 3.375 0 0 1-6.75 0ZM1.5 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM17.25 19.128l-.001.144a2.25 2.25 0 0 1-.233.96 10.088 10.088 0 0 0 5.06-1.01.75.75 0 0 0 .42-.643 4.875 4.875 0 0 0-6.957-4.611 8.586 8.586 0 0 1 1.71 5.157v.003Z" />
   </svg>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -221,7 +221,7 @@ ja:
       back: "すべての報酬に戻る"
   user_rewards:
     index:
-      heading: "あなたの報酬"
+      heading: "あなたの獲得報酬"
       all_rewards: "全ての報酬を見る"
       sort_by: "並び替え"
       newest: "新着順"


### PR DESCRIPTION
### 概要

- 小さいスクリーンでのユーザーエクスペリエンス向上のため、ボトムナビゲーションを追加しました。
- 画面サイズに応じて、ヘッダー、フッター、およびナビゲーションの表示内容を調整しました。
- ログイン前はボトムナビゲーションを非表示にし、ユーザーがログインしている場合のみ表示するようにしました。
- `PublicHabits#show`のレイアウトを`Habits#show`に合わせて更新しました。

### 変更内容

1. **ボトムナビゲーションの追加**: 小さいスクリーンサイズ時に表示されるボトムナビゲーションを追加しました。以下のリンクが含まれます。
   - 新しい習慣の作成
   - 未記録の習慣ログ
   - あなたの習慣
   - あなたの報酬

2. **ヘッダーとフッターの調整**:
   - ボトムナビゲーションが表示される際に、ヘッダーとフッターでの表示情報を調整しました。
   - 小さいスクリーンサイズ時にはヘッダーから該当リンクが非表示となり、フッターも非表示となります。

3. **レイアウトの修正**:
   - ページ全体に`padding-bottom`を追加し、ボトムナビゲーションが他の要素と被らないように調整しました。

4. **PublicHabits#show のレイアウト改善**:
   - `PublicHabits#show`のレイアウトを`Habits#show`に合わせて更新しました。

### 関連する Issue

- Issue #124
