### PR TITLE
【hotfix】Googleログインボタンの一時的な非表示対応

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -3,9 +3,11 @@
 
   <%= render 'form' %>
 
+  <!---
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <div class="divider text-gray-400">OR</div>
   </div>
 
   <%= render 'shared/google_login_button' %>
+  --->
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,9 +3,11 @@
 
   <%= render "form", user: @user, button_text: t('helpers.submit.create') %>
 
+  <!---
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <div class="divider text-gray-400">OR</div>
   </div>
 
   <%= render 'shared/google_login_button' %>
+    --->
 </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -81,9 +81,6 @@ Rails.application.config.sorcery.configure do |config|
   # Default: `[]`
   #
 
-  #externalモジュールの読み込み
-  Rails.application.config.sorcery.submodules = [:external]
-
   Rails.application.config.sorcery.configure do |config|
 
     #利用する外部サービスのプロバイダーを指定


### PR DESCRIPTION
### 概要

現在、Google OAuthの公開設定の申請中であるため、Googleログイン機能が正常に動作しない可能性があります。
そのため、ユーザーがエラーに遭遇することを防ぐために、Googleログインボタンを一時的に非表示にしました。

### 変更内容

1. **`app/views/user_sessions/new.html.erb` と `app/views/users/new.html.erb` の修正**:
   - Googleログインボタンの表示部分をコメントアウトしました。

### 背景

Google Cloud ConsoleでのOAuth同意画面の公開設定が現在審査中であり、公開が承認されるまでGoogleログイン機能が利用できない可能性があります。ユーザーがログイン時にエラーに遭遇することを防ぐため、この変更を行いました。

### 今後の対応

Google OAuthの公開設定が承認された後、コメントアウトしたコードを再度有効にして、Googleログインボタンを表示する予定です。
