### PR TITLE
【restore】Googleログインボタンの再表示

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -3,11 +3,9 @@
 
   <%= render 'form' %>
 
-  <!---
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <div class="divider text-gray-400">OR</div>
   </div>
 
   <%= render 'shared/google_login_button' %>
-  --->
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,11 +3,9 @@
 
   <%= render "form", user: @user, button_text: t('helpers.submit.create') %>
 
-  <!---
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <div class="divider text-gray-400">OR</div>
   </div>
 
   <%= render 'shared/google_login_button' %>
-    --->
 </div>


### PR DESCRIPTION
### 概要

- Google OAuthの公開設定が承認されたため、以前一時的に非表示にしていたGoogleログインボタンを再表示します。
- 以下のファイルでGoogleログインボタンのコメントアウトを解除しました。
  - `app/views/user_sessions/new.html.erb`
  - `app/views/users/new.html.erb`
